### PR TITLE
feat(docker): Add Docker development environment without Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# WordPress Admin credentials for testing
+ADMIN_USERNAME=testadmin
+ADMIN_PASSWORD=AdminPlaywright2025AdminPlaywright2025
+
+# Jury Member credentials (optional - tests can create this)
+JURY_USERNAME=jurymember1
+JURY_PASSWORD=JuryTest123!
+
+# Jury Admin credentials (optional - tests can create this)
+JURY_ADMIN_USERNAME=juryadmin
+JURY_ADMIN_PASSWORD=JuryAdmin123!
+
+# Base URLs for different environments
+LOCAL_BASE_URL=http://localhost
+STAGING_BASE_URL=http://localhost:8080
+PRODUCTION_BASE_URL=https://mobilitytrailblazers.de

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test-*.sh
 *password*
 *.env
 .env.*
+!.env.example
 wp-config.php
 wp-config-local.php
 .claude/settings.local.json

--- a/TB/.env.example
+++ b/TB/.env.example
@@ -1,0 +1,36 @@
+# Docker Environment Configuration Template for Mobility Trailblazers
+# Copy this file to .env and update with secure values
+# SECURITY: Never commit the actual .env file to version control
+
+# Database Configuration
+# Generate secure passwords: openssl rand -base64 32
+MYSQL_ROOT_PASSWORD=CHANGE_ME_USE_STRONG_PASSWORD_HERE
+MYSQL_DATABASE=wordpress_db
+MYSQL_USER=wp_user
+MYSQL_PASSWORD=CHANGE_ME_USE_STRONG_PASSWORD_HERE
+
+# WordPress Configuration
+WORDPRESS_DB_HOST=db
+WORDPRESS_DB_USER=wp_user
+WORDPRESS_DB_PASSWORD=CHANGE_ME_USE_STRONG_PASSWORD_HERE
+WORDPRESS_DB_NAME=wordpress_db
+
+# WordPress Debug Settings (set to false for production)
+WORDPRESS_DEBUG=true
+WORDPRESS_DEBUG_LOG=true
+WORDPRESS_DEBUG_DISPLAY=false
+
+# Ports Configuration
+WORDPRESS_PORT=8080
+PHPMYADMIN_PORT=8081
+# MYSQL_PORT is commented out - database not exposed to host for security
+
+# Plugin Path (relative path to plugin directory)
+PLUGIN_PATH=../Plugin
+
+# Security Note:
+# 1. Use strong, unique passwords (minimum 32 characters)
+# 2. Generate passwords with: openssl rand -base64 32
+# 3. Never use default or example passwords
+# 4. Rotate passwords regularly
+# 5. Keep .env file permissions restrictive (chmod 600 .env)

--- a/TB/Dockerfile
+++ b/TB/Dockerfile
@@ -1,0 +1,60 @@
+FROM wordpress:php8.2-apache
+
+# Install Git and other development tools
+RUN apt-get update && apt-get install -y \
+    git \
+    vim \
+    nano \
+    curl \
+    wget \
+    zip \
+    unzip \
+    mariadb-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install additional PHP extensions that might be needed
+RUN docker-php-ext-install opcache pdo_mysql mysqli
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install Node.js and npm (for frontend development)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install WP-CLI
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Enable Apache modules for WordPress
+RUN a2enmod rewrite headers expires
+
+# Create uploads directories with proper permissions
+RUN mkdir -p /var/www/html/wp-content/uploads/tmp \
+    && chown -R www-data:www-data /var/www/html/wp-content \
+    && chmod -R 755 /var/www/html/wp-content
+
+# Add Git safe directory configuration to avoid ownership issues
+RUN git config --global --add safe.directory /var/www/html/wp-content/plugins/mobility-trailblazers
+
+# Set proper permissions for the web server
+RUN chown -R www-data:www-data /var/www/html \
+    && find /var/www/html -type d -exec chmod 755 {} \; \
+    && find /var/www/html -type f -exec chmod 644 {} \;
+
+# Add a script to fix permissions after container starts
+RUN echo '#!/bin/bash\n\
+chown -R www-data:www-data /var/www/html/wp-content/uploads\n\
+chmod -R 755 /var/www/html/wp-content/uploads\n\
+chown -R www-data:www-data /var/www/html/wp-content/plugins/mobility-trailblazers\n\
+chmod -R 755 /var/www/html/wp-content/plugins/mobility-trailblazers\n\
+exec docker-entrypoint.sh apache2-foreground' > /usr/local/bin/custom-entrypoint.sh \
+    && chmod +x /usr/local/bin/custom-entrypoint.sh
+
+# Use custom entrypoint to ensure permissions are set
+ENTRYPOINT ["/usr/local/bin/custom-entrypoint.sh"]

--- a/TB/README.md
+++ b/TB/README.md
@@ -1,0 +1,179 @@
+# Docker Setup for Mobility Trailblazers WordPress Plugin
+
+## Overview
+This Docker configuration provides a complete WordPress development environment for the Mobility Trailblazers plugin with proper permissions and without Redis.
+
+## Services
+- **WordPress** (PHP 8.2 + Apache) - Port 8080
+- **MariaDB 11** - Port 3306  
+- **phpMyAdmin** - Port 8081
+- **WP-CLI** - For WordPress management
+
+## Directory Structure
+```
+MT-JURY-DASH/
+├── TB/                          # Docker configuration files
+│   ├── docker-compose.yml       # Main Docker Compose configuration
+│   ├── Dockerfile              # Custom WordPress image with tools
+│   ├── php.ini                 # PHP configuration
+│   └── .env                    # Environment variables (DO NOT COMMIT)
+├── Plugin/                     # Your plugin source code
+│   ├── assets/
+│   ├── includes/
+│   ├── templates/
+│   └── mobility-trailblazers.php
+```
+
+## Quick Start
+
+### 1. Navigate to Docker directory
+```bash
+cd C:\Users\nicol\Desktop\MT-JURY-DASH\TB
+```
+
+### 2. Start the containers
+```bash
+docker-compose up -d
+```
+
+### 3. Wait for WordPress to initialize (first run only)
+The first run will take a few minutes to download images and set up WordPress.
+
+### 4. Access the services
+- **WordPress**: http://localhost:8080
+- **phpMyAdmin**: http://localhost:8081
+- **Plugin Location**: `/wp-content/plugins/mobility-trailblazers/`
+
+## Common Commands
+
+### Start services
+```bash
+docker-compose up -d
+```
+
+### Stop services
+```bash
+docker-compose down
+```
+
+### View logs
+```bash
+# All services
+docker-compose logs -f
+
+# WordPress only
+docker-compose logs -f wordpress
+
+# Database only
+docker-compose logs -f db
+```
+
+### Execute WP-CLI commands
+```bash
+# List plugins
+docker-compose exec wpcli wp plugin list
+
+# Activate the Mobility Trailblazers plugin
+docker-compose exec wpcli wp plugin activate mobility-trailblazers
+
+# Clear cache
+docker-compose exec wpcli wp cache flush
+
+# Create admin user (first time setup)
+docker-compose exec wpcli wp user create admin admin@example.com --role=administrator --user_pass=admin123
+```
+
+### Access WordPress container shell
+```bash
+docker-compose exec wordpress bash
+```
+
+### Access database shell
+```bash
+docker-compose exec db mysql -u wp_user -p
+# Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+```
+
+## Database Access
+
+### phpMyAdmin
+- URL: http://localhost:8081
+- Server: db
+- Username: wp_user
+- Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+
+### Direct MySQL Connection
+- Host: localhost
+- Port: 3306
+- Database: wordpress_db
+- Username: wp_user
+- Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+
+## Development Features
+
+### File Permissions
+The setup automatically handles file permissions for:
+- Plugin files (read/write access)
+- Upload directories
+- Temporary files
+
+### Debug Mode
+WordPress debug mode is enabled by default with:
+- WP_DEBUG: true
+- WP_DEBUG_LOG: true
+- MT_DEBUG: true
+- Error logs: `/wp-content/debug.log`
+
+### PHP Configuration
+Custom PHP settings include:
+- Max upload: 100MB
+- Memory limit: 256MB
+- Execution time: 300s
+- Timezone: Europe/Paris
+
+## Troubleshooting
+
+### Permission Issues
+If you encounter permission issues:
+```bash
+# Fix plugin permissions
+docker-compose exec wordpress chown -R www-data:www-data /var/www/html/wp-content/plugins/mobility-trailblazers
+docker-compose exec wordpress chmod -R 755 /var/www/html/wp-content/plugins/mobility-trailblazers
+
+# Fix uploads permissions  
+docker-compose exec wordpress chown -R www-data:www-data /var/www/html/wp-content/uploads
+docker-compose exec wordpress chmod -R 755 /var/www/html/wp-content/uploads
+```
+
+### Plugin Not Appearing
+```bash
+# Check if plugin files are mounted
+docker-compose exec wordpress ls -la /var/www/html/wp-content/plugins/
+
+# Activate plugin
+docker-compose exec wpcli wp plugin activate mobility-trailblazers
+```
+
+### Database Connection Issues
+```bash
+# Check database is running
+docker-compose ps
+
+# Test database connection
+docker-compose exec wordpress wp db check
+```
+
+### Clear Everything and Start Fresh
+```bash
+# Stop and remove all containers, volumes, and networks
+docker-compose down -v
+
+# Start fresh
+docker-compose up -d
+```
+
+## Notes
+- The plugin directory is mounted from `../Plugin` (relative to TB directory)
+- All database credentials are stored in `.env` file (not committed to git)
+- WordPress data persists in Docker volumes between restarts
+- The setup uses proper www-data permissions for file uploads

--- a/TB/README.md
+++ b/TB/README.md
@@ -5,7 +5,7 @@ This Docker configuration provides a complete WordPress development environment 
 
 ## Services
 - **WordPress** (PHP 8.2 + Apache) - Port 8080
-- **MariaDB 11** - Port 3306  
+- **MariaDB 11** - Internal only (not exposed to host)  
 - **phpMyAdmin** - Port 8081
 - **WP-CLI** - For WordPress management
 
@@ -79,8 +79,9 @@ docker-compose exec wpcli wp plugin activate mobility-trailblazers
 # Clear cache
 docker-compose exec wpcli wp cache flush
 
-# Create admin user (first time setup)
-docker-compose exec wpcli wp user create admin admin@example.com --role=administrator --user_pass=admin123
+# Create admin user (first time setup) - Use a strong password!
+# Generate a secure password: openssl rand -base64 32
+docker-compose exec wpcli wp user create admin admin@example.com --role=administrator --user_pass=$(openssl rand -base64 32)
 ```
 
 ### Access WordPress container shell
@@ -90,8 +91,8 @@ docker-compose exec wordpress bash
 
 ### Access database shell
 ```bash
-docker-compose exec db mysql -u wp_user -p
-# Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+docker-compose exec db mysql -u ${MYSQL_USER} -p
+# Enter password from .env file when prompted
 ```
 
 ## Database Access
@@ -99,15 +100,15 @@ docker-compose exec db mysql -u wp_user -p
 ### phpMyAdmin
 - URL: http://localhost:8081
 - Server: db
-- Username: wp_user
-- Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+- Username: See MYSQL_USER in .env file
+- Password: See MYSQL_PASSWORD in .env file
 
-### Direct MySQL Connection
-- Host: localhost
-- Port: 3306
-- Database: wordpress_db
-- Username: wp_user
-- Password: Wp7kL9xP2qR7vN6wE3zY4uC1sA5f
+### Direct MySQL Connection (from within containers only)
+- Host: db (internal hostname)
+- Port: 3306 (internal only, not exposed to host)
+- Database: See MYSQL_DATABASE in .env file
+- Username: See MYSQL_USER in .env file
+- Password: See MYSQL_PASSWORD in .env file
 
 ## Development Features
 

--- a/TB/docker-compose.yml
+++ b/TB/docker-compose.yml
@@ -9,6 +9,14 @@ services:
     restart: unless-stopped
     ports:
       - "${WORDPRESS_PORT:-8080}:80"
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
     environment:
       WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST:-db}
       WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
@@ -60,6 +68,14 @@ services:
     image: wordpress:cli-php8.2
     container_name: mobility_wpcli_dev
     user: "33:33"  # www-data user
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
     depends_on:
       - db
       - wordpress
@@ -83,8 +99,17 @@ services:
     image: mariadb:11
     container_name: mobility_mariadb_dev
     restart: unless-stopped
-    ports:
-      - "${MYSQL_PORT:-3306}:3306"
+    # Database port removed - only accessible within Docker network
+    # ports:
+    #   - "${MYSQL_PORT:-3306}:3306"
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
     environment:
       MARIADB_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MARIADB_DATABASE: ${MYSQL_DATABASE}
@@ -110,6 +135,14 @@ services:
     restart: unless-stopped
     ports:
       - "${PHPMYADMIN_PORT:-8081}:80"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
     environment:
       PMA_HOST: db
       PMA_PORT: 3306

--- a/TB/docker-compose.yml
+++ b/TB/docker-compose.yml
@@ -1,0 +1,137 @@
+version: '3.8'
+
+services:
+  wordpress:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mobility_wordpress_dev
+    restart: unless-stopped
+    ports:
+      - "${WORDPRESS_PORT:-8080}:80"
+    environment:
+      WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST:-db}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
+      WORDPRESS_DEBUG: ${WORDPRESS_DEBUG:-true}
+      WORDPRESS_CONFIG_EXTRA: |
+        /* Development Settings */
+        define('WP_DEBUG', true);
+        define('WP_DEBUG_LOG', true);
+        define('WP_DEBUG_DISPLAY', false);
+        define('SCRIPT_DEBUG', true);
+        define('MT_DEBUG', true);
+        define('SAVEQUERIES', true);
+        
+        /* File Upload Settings */
+        define('WP_TEMP_DIR', '/var/www/html/wp-content/uploads/tmp');
+        define('UPLOADS', 'wp-content/uploads');
+        
+        /* Memory Limits */
+        define('WP_MEMORY_LIMIT', '256M');
+        define('WP_MAX_MEMORY_LIMIT', '512M');
+        
+        /* File Permissions */
+        define('FS_METHOD', 'direct');
+        define('FS_CHMOD_DIR', (0755 & ~ umask()));
+        define('FS_CHMOD_FILE', (0644 & ~ umask()));
+    volumes:
+      # Mount the plugin directory from the host to WordPress plugins directory
+      - ../Plugin:/var/www/html/wp-content/plugins/mobility-trailblazers:rw
+      
+      # Persist WordPress core files, themes, and other plugins
+      - wordpress_data:/var/www/html
+      
+      # Persist uploads directory separately for better management
+      - uploads_data:/var/www/html/wp-content/uploads
+      
+      # Temporary directory for file uploads
+      - tmp_data:/var/www/html/wp-content/uploads/tmp
+      
+      # Mount custom PHP configuration
+      - ./php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
+    depends_on:
+      - db
+    networks:
+      - mobility_network
+
+  wpcli:
+    image: wordpress:cli-php8.2
+    container_name: mobility_wpcli_dev
+    user: "33:33"  # www-data user
+    depends_on:
+      - db
+      - wordpress
+    environment:
+      WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST:-db}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
+    volumes:
+      # Mount the plugin directory
+      - ../Plugin:/var/www/html/wp-content/plugins/mobility-trailblazers:rw
+      
+      # Share WordPress data with main container
+      - wordpress_data:/var/www/html
+      - uploads_data:/var/www/html/wp-content/uploads
+    command: tail -f /dev/null
+    networks:
+      - mobility_network
+
+  db:
+    image: mariadb:11
+    container_name: mobility_mariadb_dev
+    restart: unless-stopped
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MARIADB_DATABASE: ${MYSQL_DATABASE}
+      MARIADB_USER: ${MYSQL_USER}
+      MARIADB_PASSWORD: ${MYSQL_PASSWORD}
+      MARIADB_CHARACTER_SET: utf8mb4
+      MARIADB_COLLATION: utf8mb4_unicode_ci
+    volumes:
+      - db_data:/var/lib/mysql
+      # Optional: Mount custom MySQL configuration
+      # - ./mysql/my.cnf:/etc/mysql/conf.d/custom.cnf:ro
+    networks:
+      - mobility_network
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: mobility_phpmyadmin_dev
+    restart: unless-stopped
+    ports:
+      - "${PHPMYADMIN_PORT:-8081}:80"
+    environment:
+      PMA_HOST: db
+      PMA_PORT: 3306
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      PMA_ARBITRARY: 1
+      HIDE_PHP_VERSION: 1
+      UPLOAD_LIMIT: 100M
+    depends_on:
+      - db
+    networks:
+      - mobility_network
+
+volumes:
+  wordpress_data:
+    driver: local
+  db_data:
+    driver: local
+  uploads_data:
+    driver: local
+  tmp_data:
+    driver: local
+
+networks:
+  mobility_network:
+    driver: bridge

--- a/TB/php.ini
+++ b/TB/php.ini
@@ -1,0 +1,47 @@
+; Custom PHP configuration for WordPress Development
+; File Upload Settings
+upload_max_filesize = 100M
+post_max_size = 100M
+max_file_uploads = 20
+file_uploads = On
+
+; Execution Time Settings
+max_execution_time = 300
+max_input_time = 300
+max_input_vars = 5000
+
+; Memory Settings
+memory_limit = 256M
+
+; Error Reporting (Development)
+display_errors = On
+display_startup_errors = On
+error_reporting = E_ALL
+log_errors = On
+error_log = /var/www/html/wp-content/debug.log
+
+; Session Settings
+session.gc_maxlifetime = 3600
+session.cookie_lifetime = 3600
+
+; OPcache Settings (for better performance)
+opcache.enable = 1
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 4000
+opcache.revalidate_freq = 2
+opcache.fast_shutdown = 1
+
+; Security Settings
+expose_php = Off
+allow_url_fopen = On
+allow_url_include = Off
+
+; Date/Time Settings
+date.timezone = "Europe/Paris"
+
+; Output Buffering
+output_buffering = 4096
+
+; Encoding
+default_charset = "UTF-8"


### PR DESCRIPTION
## Summary
- Configured Docker Compose setup for WordPress plugin development
- Removed Redis dependency as requested
- Fixed volume mappings and permissions for proper plugin development

## Changes
- ✅ Remove Redis service and all Redis-related configurations
- ✅ Fix volume mappings to properly mount Plugin directory
- ✅ Add proper file permissions for WordPress uploads
- ✅ Configure environment variables in .env file (not committed)
- ✅ Enhance Dockerfile with WP-CLI and development tools
- ✅ Update php.ini with development-friendly settings
- ✅ Add comprehensive README for Docker setup

## Test Plan
- [ ] Run `docker-compose up -d` in TB directory
- [ ] Verify WordPress loads at http://localhost:8080
- [ ] Check plugin appears in WordPress admin
- [ ] Test file uploads work correctly
- [ ] Verify phpMyAdmin access at http://localhost:8081

## Notes
The `.env` file with sensitive credentials is created locally but not committed to git (already in .gitignore).

🤖 Generated with [Claude Code](https://claude.ai/code)