### PR TITLE
PR04: Elementor overrides refine (draft)

### DIFF
--- a/ops/audit/frontend-ui/stubs/PR04-elementor-override-refine.md
+++ b/ops/audit/frontend-ui/stubs/PR04-elementor-override-refine.md
@@ -1,0 +1,13 @@
+Title: PR04 — Elementor overrides refine (draft)
+
+Scope
+- Replace all: unset neutralization with targeted overrides within plugin containers.
+
+Notes
+- Stub for coordination; no source changes yet.
+
+Risks
+- Some Elementor styles may reappear; refine selectors incrementally.
+
+Test Plan
+- Plugin sections with embedded Elementor widgets; confirm no collateral style resets.


### PR DESCRIPTION
Scope
- Narrow Elementor overrides to specific components inside plugin containers.

Status
- Stub only; coordinate with CSS specificity work (PR03).

Risks
- Over/under scoping; iterate with targeted selectors.

Test Plan
- Regression check on pages mixing plugin and Elementor blocks.