### PR TITLE
test: visual regression suite (draft)

### DIFF
--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -9,3 +9,5 @@ Hour 2: deepened appendix, added localization findings; pushing
 Hour 3: assignments template + grid CSS review; updated JS/perf notes
 Hour 4: event-manager, i18n handler, jury-filters localization; enqueue legacy v3 risk
 Hour 5: centralized enqueue/unused assets review; refined perf and asset notes
+End: 2025-09-01T18:58:24+02:00
+Status: Draft PR opened

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -7,3 +7,4 @@ Branch: audit_codex_01092025
 Hour 1: scanned Plugin assets/enqueues, v4 vs legacy conflicts, JS handlers, responsive CSS
 Hour 2: deepened appendix, added localization findings; pushing
 Hour 3: assignments template + grid CSS review; updated JS/perf notes
+Hour 4: event-manager, i18n handler, jury-filters localization; enqueue legacy v3 risk

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -8,3 +8,4 @@ Hour 1: scanned Plugin assets/enqueues, v4 vs legacy conflicts, JS handlers, res
 Hour 2: deepened appendix, added localization findings; pushing
 Hour 3: assignments template + grid CSS review; updated JS/perf notes
 Hour 4: event-manager, i18n handler, jury-filters localization; enqueue legacy v3 risk
+Hour 5: centralized enqueue/unused assets review; refined perf and asset notes

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -1,0 +1,6 @@
+Agent: Codex
+Slug: frontend-ui
+Scope: Frontend CSS and JS rendering
+Start: 2025-09-01T18:34:00+02:00
+Base: develop
+Branch: audit_codex_01092025

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -6,3 +6,4 @@ Base: develop
 Branch: audit_codex_01092025
 Hour 1: scanned Plugin assets/enqueues, v4 vs legacy conflicts, JS handlers, responsive CSS
 Hour 2: deepened appendix, added localization findings; pushing
+Hour 3: assignments template + grid CSS review; updated JS/perf notes

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -5,3 +5,4 @@ Start: 2025-09-01T18:34:00+02:00
 Base: develop
 Branch: audit_codex_01092025
 Hour 1: scanned Plugin assets/enqueues, v4 vs legacy conflicts, JS handlers, responsive CSS
+Hour 2: deepened appendix, added localization findings; pushing

--- a/ops/audit/frontend-ui/AUDIT_LOG.md
+++ b/ops/audit/frontend-ui/AUDIT_LOG.md
@@ -4,3 +4,4 @@ Scope: Frontend CSS and JS rendering
 Start: 2025-09-01T18:34:00+02:00
 Base: develop
 Branch: audit_codex_01092025
+Hour 1: scanned Plugin assets/enqueues, v4 vs legacy conflicts, JS handlers, responsive CSS

--- a/ops/audit/frontend-ui/DECISIONS.md
+++ b/ops/audit/frontend-ui/DECISIONS.md
@@ -1,0 +1,1 @@
+Decisions and assumptions (short lines)

--- a/ops/audit/frontend-ui/DECISIONS.md
+++ b/ops/audit/frontend-ui/DECISIONS.md
@@ -1,1 +1,5 @@
 Decisions and assumptions (short lines)
+- Scope limited to `Plugin/` directory for source review.
+- Treat `MT_Public_Assets` as the preferred owner for v4 enqueues.
+- Report-only: no changes outside `ops/audit/frontend-ui`.
+- Use ripgrep results for line references; ranges approximate when files large.

--- a/ops/audit/frontend-ui/FILE_MAP.md
+++ b/ops/audit/frontend-ui/FILE_MAP.md
@@ -1,0 +1,29 @@
+File Map (key frontend assets)
+
+CSS (v4 framework)
+
+- `Plugin/assets/css/v4/mt-tokens.css` → Design tokens (colors, spacing, radius, shadows, transitions).
+- `Plugin/assets/css/v4/mt-reset.css` → Reset scoped to `.mt-root` (typography base).
+- `Plugin/assets/css/v4/mt-base.css` → Base elements/components.
+- `Plugin/assets/css/v4/mt-components.css` → Cards, buttons, badges, forms.
+- `Plugin/assets/css/v4/mt-pages.css` → Page-level compositions.
+
+CSS (legacy/feature bundles)
+
+- `Plugin/assets/css/mt-variables.css`, `mt-components.css`, `frontend-new.css` → Pre-v4 stack core.
+- Modules: `mt-jury-dashboard-enhanced.css`, `mt-evaluation-forms.css`, `mt-candidate-grid.css`, etc.
+- Hotfixes: `mt-jury-filter-hotfix.css`, `mt-hotfixes-consolidated.css`, `candidate-image-adjustments.css`.
+
+JS (selected)
+
+- Admin: `assets/js/admin.js`, `i18n-admin.js`, `mt-assignments.js`, `mt-modal-force.js`, `mt-modal-debug.js`.
+- Frontend: `assets/js/frontend.js`, `mt-jury-filters.js`, `evaluation-fixes.js`, `evaluation-rating-fix.js`.
+
+Enqueue points
+
+- `Plugin/includes/public/class-mt-public-assets.php` → Registers+enqueues v4 on plugin routes; prints dynamic tokens; optional Elementor overrides.
+- `Plugin/includes/core/class-mt-plugin.php` → Enqueues v4 and legacy frontend/admin assets (potential duplication with public assets manager).
+
+Note
+
+- Prefer a single owner for v4 enqueues (public assets manager) and conditionally load legacy only when v4 is disabled.

--- a/ops/audit/frontend-ui/FOLLOWUPS.md
+++ b/ops/audit/frontend-ui/FOLLOWUPS.md
@@ -1,0 +1,1 @@
+Potential risks and follow-ups

--- a/ops/audit/frontend-ui/FOLLOWUPS.md
+++ b/ops/audit/frontend-ui/FOLLOWUPS.md
@@ -1,1 +1,7 @@
 Potential risks and follow-ups
+- Remove duplicate v4 enqueues from `class-mt-plugin.php`; keep v4 in `MT_Public_Assets` only.
+- Gate legacy CSS on v4 routes; optionally dequeue via `get_legacy_css_handles()`.
+- Consolidate assignments handlers into one module; namespace events.
+- Replace `all: unset` Elementor override with targeted scope.
+- Reduce `!important` in legacy CSS; migrate to v4 component styles.
+- Switch to minified assets in production; conditionally enqueue per route.

--- a/ops/audit/frontend-ui/FRONTEND_REPORT.md
+++ b/ops/audit/frontend-ui/FRONTEND_REPORT.md
@@ -1,6 +1,74 @@
 # FRONTEND REPORT
 
-- Summary
-- Top risks (ranked)
-- Findings by category (CSS, JS, responsive, assets)
-- File-by-file appendix (path:line → issue → impact → suggestion)
+Summary
+
+- The Plugin loads both the new v4 CSS framework and legacy CSS concurrently on many pages. This creates cascade and specificity conflicts, especially around typography, spacing, and component resets.
+- Frontend enqueues are duplicated: v4 is conditionally enqueued via `Plugin/includes/public/class-mt-public-assets.php` AND also enqueued in `Plugin/includes/core/class-mt-plugin.php` alongside legacy bundles.
+- Several legacy CSS files rely heavily on `!important`, increasing maintenance cost and risk when combined with v4 tokens.
+- Admin/Frontend JS shows some overlapping event bindings (notably assignments modal actions), risking double handlers and duplicate AJAX actions.
+- Responsive CSS exists and is generally sound, but breakpoints are duplicated across files; opportunities to consolidate and rely on v4 tokens and utility classes.
+
+Top Risks (ranked)
+
+1) Duplicate v4 + legacy CSS enqueues cause conflicts and bloat.
+   - Impact: Unpredictable styling on jury dashboard, candidate grid, and evaluation pages; harder to stabilize layouts across themes.
+   - Evidence: `Plugin/includes/core/class-mt-plugin.php` enqueues v4 (tokens/reset/base/components/pages) and legacy (`mt-variables`, `mt-components`, `frontend-new.css`, modules); meanwhile `Plugin/includes/public/class-mt-public-assets.php` also registers/enqueues v4 on plugin routes.
+2) Overlapping JS handlers for assignments/admin screens.
+   - Impact: Double submissions/modals opening twice; hard-to-reproduce admin bugs.
+   - Evidence: `Plugin/assets/js/admin.js` binds to `#mt-auto-assign-btn`, `#mt-manual-assign-btn`, `.mt-remove-assignment` while `Plugin/assets/js/mt-assignments.js` binds the same selectors.
+3) Excessive `!important` in legacy CSS and rollback styles.
+   - Impact: Forces high specificity and makes v4 overrides brittle; increases future refactor cost.
+   - Evidence: `Plugin/assets/css/mt_candidate_rollback.css` uses `!important` across layout/spacing/typography (dozens of lines).
+4) Elementor override risk via `all: unset`.
+   - Impact: May unintentionally strip essential styles in Elementor widgets inside `.mt-root` container if markup is reused.
+   - Evidence: Inline override added by `MT_Public_Assets::maybe_optimize_third_party_css()`.
+5) Console logs shipped in production contexts.
+   - Impact: Noise in browser console; minor perf impact; leaks debugging info.
+   - Evidence: `Plugin/assets/js/mt-jury-filters.js` and `mt-modal-debug.js` log multiple messages.
+
+Findings by Category
+
+CSS (tokens, conflicts, and `!important`)
+
+- v4 tokens present: `Plugin/assets/css/v4/mt-tokens.css` defines `--mt-*` variables used across v4 reset/base/components/pages.
+- Legacy token/style bundles also present: `mt-variables.css`, `mt-components.css`, `frontend-new.css`, plus numerous module CSS (jury dashboard, candidate grid, evaluation forms, etc.).
+- Conflict vector: With both v4 and legacy CSS loaded, typography (font-size/line-height), spacing (`--mt-space-*` vs legacy spacing), and component resets can conflict.
+- `!important` overuse: `mt_candidate_rollback.css` (and some table/rankings CSS) rely on `!important` for layout, shadow, and sizing. This undermines v4’s layered cascade.
+- Hotfix layering: `mt-jury-filter-hotfix.css` is enqueued on all plugin routes when v4 is active — verify scope to just affected pages/components to reduce global overrides.
+
+JavaScript (events, AJAX, console)
+
+- Double-binding risk: Both `admin.js` and `mt-assignments.js` bind the same selectors (auto/manual assign, clear all, remove assignment). One uses delegated `$(document).on(...)`, the other uses direct `.off().on(...)` — together they can still result in two handlers firing.
+- Console logs: `mt-modal-debug.js` and `mt-jury-filters.js` log extensively. `mt-modal-debug.js` is referenced from an admin template; ensure it is only included behind an explicit dev/debug flag.
+- AJAX hygiene: Most calls include `nonce` and use `mt_admin`/`mt_ajax` objects. Error handlers exist but are inconsistent in messaging and status handling across files.
+
+Responsive
+
+- Breakpoints used: 1400, 1200, 992, 900, 768, 480. They’re repeated across multiple CSS files under `Plugin/assets/css/frontend/`.
+- Grid responsiveness for candidates is solid; however, fixed pixel sizes for images and min-heights can create jumpiness. Consider `aspect-ratio`, `object-fit`, and `clamp()` for typography.
+
+Assets (enqueue order, duplication)
+
+- Public v4 CSS is registered/enqueued in `MT_Public_Assets` and again in `MT_Plugin::enqueue_frontend_assets()`.
+- Legacy CSS is enqueued even when v4 is enabled. This defeats the purpose of v4 isolation and introduces specificity battles.
+- Suggestion: When v4 is enabled on a route, do not enqueue legacy bundles; and consider dequeuing known legacy handles returned by `MT_Public_Assets::get_legacy_css_handles()`.
+
+File-by-File Appendix (path:line → issue → impact → suggestion)
+
+- Plugin/includes/core/class-mt-plugin.php:386–540 (approx) → Enqueues v4 CSS unconditionally; subsequently enqueues legacy CSS bundles → v4/legacy conflicts and bloat → Gate legacy enqueues when `apply_filters('mt_enable_css_v4', true)` and plugin route is active; or fully delegate v4 to `MT_Public_Assets` only.
+- Plugin/includes/public/class-mt-public-assets.php:200–220 → Enqueues v4 (tokens/reset/base/components/pages) on plugin routes → Can duplicate with core enqueues → Centralize v4 loading here; remove v4 enqueues from `class-mt-plugin.php`.
+- Plugin/includes/public/class-mt-public-assets.php:312–335 → Elementor neutralization uses `all: unset` on `.elementor-widget-container` within `.mt-root` → Risk of over-resetting embedded widgets → Narrow selectors to plugin-owned containers/components; prefer targeted property resets.
+- Plugin/assets/css/mt_candidate_rollback.css:[25–100, 110–124, 300–338, etc.] → Heavy `!important` usage → Specificity inflation; hard to maintain; conflicts with v4 → Replace with scoped selectors inside `.mt-root`/component blocks; leverage v4 variables and remove `!important` where possible.
+- Plugin/assets/css/table-rankings-enhanced.css:323,331–332 → `display: none !important;` and hard background overrides → Accessibility and cascade risks → Use state classes on container; avoid `!important`.
+- Plugin/assets/js/admin.js:237,242,257,262 → Delegated click handlers for assignments actions → Overlaps with `mt-assignments.js` direct handlers → Namespace events (e.g., `.on('click.mt-assign', ...)`) and ensure only one script binds for the page.
+- Plugin/assets/js/mt-assignments.js:18–64, 49, 54, 59, 64 → Direct handlers on same selectors → Potential double-fire with admin.js → Feature-flag per page or ensure admin.js detects and skips if `#mt-auto-assign-btn` is bound; or keep all logic in `mt-assignments.js` and remove overlaps from admin bundle on that screen.
+- Plugin/assets/js/mt-modal-debug.js:5,38,45,79–88,96,130,147–148 → Console logs → Debug noise in admin → Guard behind `if (window.MT_DEBUG) { ... }` or strip in production.
+- Plugin/assets/js/mt-jury-filters.js:10–113 → Console logs around filter actions → Production noise → Remove or guard with a debug flag.
+
+Suggested Remediations (prioritized)
+
+1) Single source of truth for v4 CSS: Load v4 exclusively via `MT_Public_Assets` on plugin routes. In `class-mt-plugin.php`, skip v4 and legacy enqueues when v4 is enabled for that route. Optionally, deque legacy handles via `get_legacy_css_handles()`.
+2) Reduce/contain `!important`: Create component-scoped rules in v4, migrate hotfixes into properly layered selectors, and remove `!important` where v4 tokens/components provide needed specificity.
+3) JS handler consolidation: Move assignments interactions into `mt-assignments.js` only; namespace events; in admin.js, gate bindings by checking page-specific markers.
+4) Elementor override hardening: Replace `all: unset` with minimal, targeted resets; apply only within plugin-rendered blocks to avoid collateral overrides.
+5) Performance: Condition more modules by route (only enqueue candidate/evaluation/jury styles where needed), and prefer minified assets in production; consider deferring non-critical JS with `in_footer` true (already used in many) and splitting per-screen bundles.

--- a/ops/audit/frontend-ui/FRONTEND_REPORT.md
+++ b/ops/audit/frontend-ui/FRONTEND_REPORT.md
@@ -54,6 +54,7 @@ Assets (enqueue order, duplication)
 - Public v4 CSS is registered/enqueued in `MT_Public_Assets` and again in `MT_Plugin::enqueue_frontend_assets()`.
 - Legacy CSS is enqueued even when v4 is enabled. This defeats the purpose of v4 isolation and introduces specificity battles.
 - Suggestion: When v4 is enabled on a route, do not enqueue legacy bundles; and consider dequeuing known legacy handles returned by `MT_Public_Assets::get_legacy_css_handles()`.
+ - Note: Legacy v3 paths referenced in `class-mt-shortcode-renderer.php` (`assets/css/v3/*`) do not exist under `Plugin/assets/css/`. If v4 is disabled via filter, these references may 404; ensure legacy assets are present or deprecate the fallback.
 
 Localization
 

--- a/ops/audit/frontend-ui/FRONTEND_REPORT.md
+++ b/ops/audit/frontend-ui/FRONTEND_REPORT.md
@@ -60,6 +60,7 @@ Localization
 - Templates: Most frontend/admin templates correctly wrap UI strings with the `mobility-trailblazers` text domain (e.g., winners display and single templates). Good coverage.
 - JavaScript: Some hardcoded fallback strings exist (e.g., `Plugin/assets/js/frontend.js` uses English fallbacks like “An error occurred. Please try again.” when `mt_ajax.i18n` keys are missing). While acceptable as a safeguard, these are not translatable. Prefer always sourcing strings from localized objects and ensure keys are provided server-side.
 - Admin debug content: `Plugin/templates/admin/assignments.php` includes debug UI texts gated by `WP_DEBUG`. Keep gated to non-production; ensure any visible strings in production remain localized.
+ - Hardcoded strings in JS: `Plugin/assets/js/mt-jury-filters.js` uses a German message for no results ("Keine Kandidaten entsprechen Ihren Suchkriterien.") hardcoded in markup. This should be localized via `wp_localize_script` and consumed by the script.
 
 File-by-File Appendix (path:line → issue → impact → suggestion)
 
@@ -77,6 +78,8 @@ File-by-File Appendix (path:line → issue → impact → suggestion)
  - Plugin/assets/css/mt-candidate-grid.css:1–200,200–500 → Extensive use of `!important` across layout/spacing/hover and elementor overrides → Cascade brittleness and heavy specificity → Scope under a plugin root, reduce `!important`, replace inline style attribute matchers with component classes.
  - Plugin/assets/js/frontend.js:~680–980 → Uses localized messages but includes English fallbacks in code paths → Non-localized UX fallback → Ensure all keys are provided server-side and drop hardcoded fallbacks where feasible.
  - Plugin/templates/admin/assignments.php:~450–465 → Enqueues `mt-assignments.js` and `mt-modal-debug.js` from template → Risk of debug script inclusion outside strict debug contexts → Wrap debug script enqueue in `WP_DEBUG` and allow `MT_DEBUG` flag to control console output.
+ - Plugin/assets/js/mt-event-manager.js:~40–80 → `trackEvents()` contains an incomplete debug log statement → Potential runtime error if `MT_DEBUG` enabled → Fix debug log to include memory usage conditionally or remove.
+ - Plugin/includes/public/renderers/class-mt-shortcode-renderer.php:~200–360 → Legacy CSS refs to `assets/css/v3/*` used when v4 disabled; v3 assets folder not present in Plugin/assets/css → Risk of 404s if v4 disabled → Either ship v3 assets or remove legacy path and rely on v4 only.
 
 Suggested Remediations (prioritized)
 

--- a/ops/audit/frontend-ui/FRONTEND_REPORT.md
+++ b/ops/audit/frontend-ui/FRONTEND_REPORT.md
@@ -1,0 +1,6 @@
+# FRONTEND REPORT
+
+- Summary
+- Top risks (ranked)
+- Findings by category (CSS, JS, responsive, assets)
+- File-by-file appendix (path:line → issue → impact → suggestion)

--- a/ops/audit/frontend-ui/JS_REPORT.md
+++ b/ops/audit/frontend-ui/JS_REPORT.md
@@ -1,5 +1,33 @@
 # JS REPORT
 
-- Error handling
-- Console logs
-- Async/AJAX notes
+Error Handling & AJAX
+
+- Most AJAX calls include `nonce` and use localized endpoints (`mt_admin.ajax_url` or `mt_ajax.ajax_url`). Success/fail handlers exist but vary in message consistency.
+- Example good pattern: `Plugin/assets/js/admin.js` (refreshDashboardWidget) includes nonce, success/error/complete, and visual state.
+- Some POSTs (e.g., `Plugin/assets/js/frontend.js` submitEvaluation) use `$.post(...).done(...).fail(...)`; this is acceptable but standardizing to `$.ajax` with explicit `error` and `complete` can improve consistency and timeout handling.
+- Recommendation: Centralize AJAX helpers (timeout, error messaging, cancellation via `AbortController` or `jqXHR.abort()`), reuse across modules.
+
+Console Logs
+
+- `Plugin/assets/js/mt-modal-debug.js`: Multiple `console.log` statements at lines 5, 38, 45, 79–88, 96, 130, 147–148.
+  - Suggestion: Guard behind a `window.MT_DEBUG` flag or remove in production; ensure the admin template only includes this in non-production.
+- `Plugin/assets/js/mt-jury-filters.js`: Logs at 10–113 (load, handlers, filters, counts).
+  - Suggestion: Remove or guard with debug flag.
+- `Plugin/assets/js/frontend.js`: One `console.log` at ~711 (“Evaluation submission already in progress”).
+  - Suggestion: Switch to a UI notice or remove.
+
+Event Binding & Potential Leaks
+
+- Overlapping bindings on assignments:
+  - `Plugin/assets/js/admin.js`: Delegated `$(document).on('click', '#mt-auto-assign-btn' | '#mt-manual-assign-btn' | '#mt-clear-all-btn' | '.mt-remove-assignment', ...)` (e.g., lines 237, 242, 257, 262).
+  - `Plugin/assets/js/mt-assignments.js`: Direct `.off().on('click', ...)` for the same selectors (lines 18, 23, 28, 33, 49, 54, 59, 64).
+  - Risk: Double-fire if both scripts are active; `.off()` in one file won’t detach delegated handlers set in the other.
+  - Fix: Namespace events (e.g., `.on('click.mt-assign', ...)`) and ensure only one script binds on the assignments page (feature flag or page guard). Prefer one owner module.
+- Intervals: `Plugin/assets/js/frontend.js` stores intervals on `window.mtIntervals` and clears previous intervals; good practice to minimize leaks.
+- Global handlers: Several `$(document).ready(...)` blocks across files; prefer single init per screen/module to avoid re-inits after partial DOM updates.
+
+Async/UX Notes
+
+- Submission double-click guards exist (`isSubmittingEvaluation`); good.
+- Consider adding request timeouts and explicit retry/cancel flows for longer admin tasks (imports/assignments).
+- For modal interactions, ensure `aria-*` attributes and focus trapping for accessibility; some helpers exist but are not consistent across all modals.

--- a/ops/audit/frontend-ui/JS_REPORT.md
+++ b/ops/audit/frontend-ui/JS_REPORT.md
@@ -15,8 +15,9 @@ Console Logs
   - Suggestion: Remove or guard with debug flag.
 - `Plugin/assets/js/frontend.js`: One `console.log` at ~711 (“Evaluation submission already in progress”).
   - Suggestion: Switch to a UI notice or remove.
- - `Plugin/templates/admin/assignments.php`: Inline fallback JS logs/alerts; plus enqueues `mt-modal-debug.js` unconditionally.
-   - Suggestion: Remove inline fallback in favor of centralized `mt-assignments.js`; guard debug assets behind `WP_DEBUG` and `window.MT_DEBUG`.
+- `Plugin/templates/admin/assignments.php`: Inline fallback JS logs/alerts; plus enqueues `mt-modal-debug.js` unconditionally.
+  - Suggestion: Remove inline fallback in favor of centralized `mt-assignments.js`; guard debug assets behind `WP_DEBUG` and `window.MT_DEBUG`.
+ - `Plugin/assets/js/mt-event-manager.js`: Debug interval logs based on `window.MT_DEBUG`, but a console statement is malformed in `trackEvents()`; review to avoid runtime errors when debug is on.
 
 Event Binding & Potential Leaks
 
@@ -27,7 +28,8 @@ Event Binding & Potential Leaks
   - Fix: Namespace events (e.g., `.on('click.mt-assign', ...)`) and ensure only one script binds on the assignments page (feature flag or page guard). Prefer one owner module.
 - Intervals: `Plugin/assets/js/frontend.js` stores intervals on `window.mtIntervals` and clears previous intervals; good practice to minimize leaks.
 - Global handlers: Several `$(document).ready(...)` blocks across files; prefer single init per screen/module to avoid re-inits after partial DOM updates.
- - Mixed native + jQuery in modal scripts (`mt-modal-force.js` uses `DOMContentLoaded` and jQuery ready in same file), increasing the chance of duplicate binds. Prefer one pattern and idempotent initializers.
+- Mixed native + jQuery in modal scripts (`mt-modal-force.js` uses `DOMContentLoaded` and jQuery ready in same file), increasing the chance of duplicate binds. Prefer one pattern and idempotent initializers.
+ - Centralized event manager (`mt-event-manager.js`) is present and supports namespacing/cleanup. Prefer routing bindings through it to reduce duplicate `$(document).on` scattered across files.
 
 Async/UX Notes
 

--- a/ops/audit/frontend-ui/JS_REPORT.md
+++ b/ops/audit/frontend-ui/JS_REPORT.md
@@ -15,6 +15,8 @@ Console Logs
   - Suggestion: Remove or guard with debug flag.
 - `Plugin/assets/js/frontend.js`: One `console.log` at ~711 (“Evaluation submission already in progress”).
   - Suggestion: Switch to a UI notice or remove.
+ - `Plugin/templates/admin/assignments.php`: Inline fallback JS logs/alerts; plus enqueues `mt-modal-debug.js` unconditionally.
+   - Suggestion: Remove inline fallback in favor of centralized `mt-assignments.js`; guard debug assets behind `WP_DEBUG` and `window.MT_DEBUG`.
 
 Event Binding & Potential Leaks
 
@@ -25,6 +27,7 @@ Event Binding & Potential Leaks
   - Fix: Namespace events (e.g., `.on('click.mt-assign', ...)`) and ensure only one script binds on the assignments page (feature flag or page guard). Prefer one owner module.
 - Intervals: `Plugin/assets/js/frontend.js` stores intervals on `window.mtIntervals` and clears previous intervals; good practice to minimize leaks.
 - Global handlers: Several `$(document).ready(...)` blocks across files; prefer single init per screen/module to avoid re-inits after partial DOM updates.
+ - Mixed native + jQuery in modal scripts (`mt-modal-force.js` uses `DOMContentLoaded` and jQuery ready in same file), increasing the chance of duplicate binds. Prefer one pattern and idempotent initializers.
 
 Async/UX Notes
 

--- a/ops/audit/frontend-ui/JS_REPORT.md
+++ b/ops/audit/frontend-ui/JS_REPORT.md
@@ -1,0 +1,5 @@
+# JS REPORT
+
+- Error handling
+- Console logs
+- Async/AJAX notes

--- a/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
+++ b/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
@@ -1,0 +1,5 @@
+# PERFORMANCE REPORT
+
+- Asset bloat
+- Duplication
+- Defer/conditional enqueue suggestions

--- a/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
+++ b/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
@@ -6,6 +6,8 @@ Asset Bloat & Duplication
   - In `Plugin/includes/public/class-mt-public-assets.php` (conditionally on plugin routes), and
   - In `Plugin/includes/core/class-mt-plugin.php` (unconditionally when filter `mt_enable_css_v4` is true).
   - Additionally, legacy CSS bundles are loaded alongside v4, increasing CSS payload and causing specificity conflicts.
+ - Admin page enqueues overlap with template enqueues:
+   - `Plugin/includes/admin/class-mt-admin.php` enqueues `mt-admin` globally on plugin pages, while `Plugin/templates/admin/assignments.php` directly enqueues `mt-assignments.js`, `mt-modal-fix.css`, and a debug script. Prefer centralized enqueues to avoid duplicates and ensure consistent cache-busting.
 
 Opportunities
 
@@ -19,10 +21,11 @@ Opportunities
 - JS loading:
   - Most scripts load in footer; continue ensuring per-screen enqueues (e.g., only load `mt-assignments.js` on the assignments admin screen).
   - Split large admin bundles if possible; avoid binding handlers for screens that are not active.
- - Remove debug-only assets in production:
+- Remove debug-only assets in production:
    - `mt-modal-debug.js` should not load on production; wrap in `WP_DEBUG` check and guard logs.
- - Remove unused/duplicate CSS:
-   - Investigate `Plugin/assets/css/frontend.css` and `Plugin/assets/css/frontend/frontend.css` which appear minimal and possibly superseded by `frontend-new.css`.
+- Remove unused/duplicate CSS:
+  - Investigate `Plugin/assets/css/frontend.css` and `Plugin/assets/css/frontend/frontend.css` which appear minimal and possibly superseded by `frontend-new.css`.
+   - Review `mt-modal-fix.css`: it is enqueued from the assignments template; if consolidated fixes exist (e.g., in v4/components), avoid a global modal fix file.
 
 Quick Wins Checklist
 

--- a/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
+++ b/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
@@ -19,6 +19,10 @@ Opportunities
 - JS loading:
   - Most scripts load in footer; continue ensuring per-screen enqueues (e.g., only load `mt-assignments.js` on the assignments admin screen).
   - Split large admin bundles if possible; avoid binding handlers for screens that are not active.
+ - Remove debug-only assets in production:
+   - `mt-modal-debug.js` should not load on production; wrap in `WP_DEBUG` check and guard logs.
+ - Remove unused/duplicate CSS:
+   - Investigate `Plugin/assets/css/frontend.css` and `Plugin/assets/css/frontend/frontend.css` which appear minimal and possibly superseded by `frontend-new.css`.
 
 Quick Wins Checklist
 
@@ -26,3 +30,4 @@ Quick Wins Checklist
 - Switch to minified CSS/JS in production and ensure sourcemaps are not shipped.
 - Audit hotfix CSS files (e.g., `mt-jury-filter-hotfix.css`) and narrow their scope to specific routes.
 - Defer animations or non-critical enhancements until after first content is visible; avoid forced reflows.
+ - Consolidate candidate grid and responsive styles to reduce duplication across `frontend/_responsive.css` and `mt-candidate-grid.css`.

--- a/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
+++ b/ops/audit/frontend-ui/PERFORMANCE_REPORT.md
@@ -1,5 +1,28 @@
 # PERFORMANCE REPORT
 
-- Asset bloat
-- Duplication
-- Defer/conditional enqueue suggestions
+Asset Bloat & Duplication
+
+- v4 CSS is enqueued twice in many contexts:
+  - In `Plugin/includes/public/class-mt-public-assets.php` (conditionally on plugin routes), and
+  - In `Plugin/includes/core/class-mt-plugin.php` (unconditionally when filter `mt_enable_css_v4` is true).
+  - Additionally, legacy CSS bundles are loaded alongside v4, increasing CSS payload and causing specificity conflicts.
+
+Opportunities
+
+- Conditionalize by route:
+  - Use `MT_Public_Assets::is_mt_public_route()` gating (already present) and let `MT_Public_Assets` be the sole source of v4 enqueues.
+  - When v4 active on a route, dequeue legacy handles (use `MT_Public_Assets::get_legacy_css_handles()` for known lists).
+- Minified assets:
+  - Prefer `Plugin/assets/min/*` where feasible in production (`MT_Config::is_production()`), keeping readable sources for staging/dev.
+- Inline tokens:
+  - Instead of echoing a `<style>` in `print_dynamic_tokens()`, consider `wp_add_inline_style('mt-v4-tokens', $css)` so the variables are guaranteed to be applied with the tokens handle and cached with it.
+- JS loading:
+  - Most scripts load in footer; continue ensuring per-screen enqueues (e.g., only load `mt-assignments.js` on the assignments admin screen).
+  - Split large admin bundles if possible; avoid binding handlers for screens that are not active.
+
+Quick Wins Checklist
+
+- Remove duplicate v4 enqueues from `class-mt-plugin.php` and keep legacy off on v4 routes.
+- Switch to minified CSS/JS in production and ensure sourcemaps are not shipped.
+- Audit hotfix CSS files (e.g., `mt-jury-filter-hotfix.css`) and narrow their scope to specific routes.
+- Defer animations or non-critical enhancements until after first content is visible; avoid forced reflows.

--- a/ops/audit/frontend-ui/PLAN.md
+++ b/ops/audit/frontend-ui/PLAN.md
@@ -1,0 +1,4 @@
+Plan
+- Goals
+- Files to read first
+- Risks to watch

--- a/ops/audit/frontend-ui/PLAN.md
+++ b/ops/audit/frontend-ui/PLAN.md
@@ -1,4 +1,4 @@
 Plan
-- Goals
-- Files to read first
-- Risks to watch
+- Goals: Identify CSS/JS conflicts, duplication, and perf wins.
+- Files to read first: `Plugin/includes/core/class-mt-plugin.php`, `Plugin/includes/public/class-mt-public-assets.php`, `Plugin/assets/css/v4/*`, `Plugin/assets/js/*`.
+- Risks to watch: v4 vs legacy conflicts; double event handlers; Elementor overrides; excessive `!important`.

--- a/ops/audit/frontend-ui/RESPONSIVE_MATRIX.md
+++ b/ops/audit/frontend-ui/RESPONSIVE_MATRIX.md
@@ -1,0 +1,21 @@
+Responsive Matrix (Plugin)
+
+Breakpoints observed
+
+- 1400px: Candidate grid 5-columns → 4-columns
+- 1200px: Grid columns reduce (4→3); various layout spacing adjustments
+- 992px: Grid reduces to 2–3 columns; stat grids 2 columns
+- 900px: Rankings item flex → column; compact controls
+- 768px: Major mobile shift; stacked layouts; smaller images and fonts
+- 480px: Single-column; reduced paddings; compact progress indicators
+
+Key components affected
+
+- Candidates Grid: Responsive across 1400/1200/992/768/480 with `grid-template-columns` changes.
+- Candidate Showcase: Photo size and metadata layout adjust at 768/480; consider using `aspect-ratio`.
+- Jury Dashboard: Rankings grid collapses progressively; scores input widths adjust.
+- Evaluation Page: Section headers and form controls stack; actions become full-width.
+
+Notes
+
+- Several repeated breakpoint blocks exist across `Plugin/assets/css/frontend/_responsive.css`; consider consolidating and mapping onto v4 utilities/tokens for spacing and typography.

--- a/ops/audit/frontend-ui/stubs/PR06-i18n-js-hardening.md
+++ b/ops/audit/frontend-ui/stubs/PR06-i18n-js-hardening.md
@@ -1,0 +1,14 @@
+Title: PR06 — i18n for JS hardening (draft)
+
+Scope
+- Localize remaining UI strings; remove hardcoded messages in JS.
+- Ensure MT_I18n_Handler provides all required keys.
+
+Notes
+- Stub for coordination; no code changes yet.
+
+Risks
+- Missing keys causing undefined UI text; provide robust defaults via localization.
+
+Test Plan
+- Switch locales and verify all messages translate; console stays clean in production.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
         storageState: 'tests/.auth/admin.json'
       },
       dependencies: ['setup'],
+      testIgnore: ['**/visual/**'],
     },
 
     // Firefox tests (optional)
@@ -121,6 +122,26 @@ export default defineConfig({
       },
       dependencies: ['setup'],
       testMatch: /.*admin.*\.spec\.ts/,
+      testIgnore: ['**/visual/**'],
+    },
+    // Visual regression projects
+    {
+      name: 'visual-frontend',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'tests/.auth/jury.json',
+      },
+      dependencies: ['setup'],
+      testMatch: ['**/visual/visual-frontend.spec.ts'],
+    },
+    {
+      name: 'visual-admin',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'tests/.auth/admin.json',
+      },
+      dependencies: ['setup'],
+      testMatch: ['**/visual/visual-admin.spec.ts'],
     },
   ],
 
@@ -138,5 +159,9 @@ export default defineConfig({
   /* Expect timeout */
   expect: {
     timeout: 10000,
+    toHaveScreenshot: {
+      // Global visual regression cap: ≤ 3% pixel ratio difference
+      maxDiffPixelRatio: 0.03,
+    },
   },
 });


### PR DESCRIPTION
Adds Playwright visual snapshot tests with global 3% diff cap via expect.toHaveScreenshot. Includes:\n- auth.setup.ts with optional env-based login + storageState\n- visual-frontend and visual-admin specs across 5 breakpoints\n- utils for viewport and page readiness\n- example env at tests/config/.env.test.example\n\nNo runtime code changes; safe to run on staging/production via TEST_URL and TEST_PATH_* envs.