### PR TITLE
ci: guard legacy folders + i18n output path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/includes/**  @nicolasestrem
+/languages/** @nicolasestrem
+

--- a/.github/workflows/block-legacy-folders.yml
+++ b/.github/workflows/block-legacy-folders.yml
@@ -1,0 +1,34 @@
+name: Block legacy folders (includes/, languages/ at repo root)
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - nightly-build
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Guard against root includes/
+        shell: bash
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}... | grep -E '^includes/'; then
+            echo "Root 'includes/' is not allowed. Use 'Plugin/includes/' instead." >&2
+            exit 1
+          fi
+
+      - name: Guard against root languages/
+        shell: bash
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}... | grep -E '^languages/'; then
+            echo "Root 'languages/' is not allowed. Use 'Plugin/languages/' instead." >&2
+            exit 1
+          fi
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18n:compile": "php scripts/german-translation-automation.php compile",
     "i18n:validate": "php scripts/validate-translation-deployment.php",
     "i18n:validate:verbose": "php scripts/validate-translation-deployment.php -v",
-    "i18n:update-pot": "wp i18n make-pot . languages/mobility-trailblazers.pot --domain=mobility-trailblazers --exclude=vendor,node_modules,tests,build",
+    "i18n:update-pot": "wp i18n make-pot Plugin Plugin/languages/mobility-trailblazers.pot --domain=mobility-trailblazers --exclude=vendor,node_modules,tests,build",
     "i18n:install-hooks": "bash scripts/install-translation-hooks.sh",
     "i18n:check": "npm run i18n:analyze && npm run i18n:validate",
     "predeploy": "npm run i18n:validate",


### PR DESCRIPTION
- Block root includes/ and languages/ via CI
- Add CODEOWNERS for includes/** and languages/**
- Update i18n make-pot to output into Plugin/languages

This prevents reintroducing legacy folders and aligns i18n artifacts with the canonical Plugin structure.